### PR TITLE
Remove <pre> tag error message

### DIFF
--- a/src/components/fields/ObjectField.js
+++ b/src/components/fields/ObjectField.js
@@ -221,15 +221,11 @@ class ObjectField extends Component {
       const properties = Object.keys(schema.properties || {});
       orderedProperties = orderProperties(properties, uiSchema["ui:order"]);
     } catch (err) {
-      return (
-        <div>
-          <p className="config-error" style={{ color: "red" }}>
-            Invalid {name || "root"} object field configuration:
-            <em>{err.message}</em>.
-          </p>
-          <pre>{JSON.stringify(schema)}</pre>
-        </div>
-      );
+      console.error(`Invalid ${name || "root"} object field configuration`, {
+        err,
+        schema,
+      });
+      return null;
     }
 
     const Template = registry.ObjectFieldTemplate || DefaultObjectFieldTemplate;


### PR DESCRIPTION
### Reasons for making this change

Console log instead of rendering error message. Prevents unformatted blocks from showing in the UI.

### Checklist

* [ ] **I'm updating documentation**
  - [ ] I've [checked the rendering](https://react-jsonschema-form.readthedocs.io/en/latest/#contributing) of the Markdown text I've added
* [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests
  - [ ] I've updated [docs](https://react-jsonschema-form.readthedocs.io/) if needed
  - [ ] I've run `npm run cs-format` on my branch to conform my code to [prettier](https://github.com/prettier/prettier) coding style
* [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
